### PR TITLE
get_history() method raising errors

### DIFF
--- a/nsepy/history.py
+++ b/nsepy/history.py
@@ -110,11 +110,17 @@ def get_history(symbol, start, end, index=False, futures=False, option_type="",
                         2. If there's an Invalid value in option_type, valid values-'CE' or 'PE' or 'CA' or 'CE'
                         3. If both futures='True' and option_type='CE' or 'PE'
     """
-    frame = inspect.currentframe()
-    args, _, _, kwargs = inspect.getargvalues(frame)
-    del(kwargs['frame'])
-    start = kwargs['start']
-    end = kwargs['end']
+    kwargs = {
+        'symbol': symbol,
+        'start': start,
+        'end': end,
+        'index': index,
+        'futures': futures,
+        'option_type': option_type,
+        'expiry_date': expiry_date,
+        'strike_price': strike_price,
+        'series': series
+    }
     if (end - start) > timedelta(130):
         kwargs1 = dict(kwargs)
         kwargs2 = dict(kwargs)
@@ -172,9 +178,11 @@ def validate_params(symbol, start, end, index=False, futures=False, option_type=
     """
 
     params = {}
-
     if start > end:
-        raise ValueError('Please check start and end dates')
+        end, start = start, end
+        return validate_params(symbol, start, end, index, futures, option_type,
+                    expiry_date, strike_price, series)
+        # raise ValueError('Please check start and end dates')
     
     
     if (futures and not option_type) or (not futures and option_type): #EXOR


### PR DESCRIPTION
The inspect frames and other things in the history.py for get_history() method was raising some error that recieved some "frame" argument. I tried temporarily to fix it by creating the kwargs dictionary. It worked for now. Please have a look once.

I was getting an error that start was greater than end for the below symbols while start as higher than end.
`
     ['AARVEEDEN', 'APOLLOTYRE']`
I did a temporary fix by calling the function by changing end and start dates.


![image](https://cloud.githubusercontent.com/assets/10350711/20896966/23006fc4-bb46-11e6-96c4-52439b0a5828.png)
